### PR TITLE
Fix error due to numpy deprecation

### DIFF
--- a/iDEA/methods/non_interacting.py
+++ b/iDEA/methods/non_interacting.py
@@ -86,7 +86,7 @@ def kinetic_energy_operator(s: iDEA.system.System) -> np.ndarray:
                     864,
                     -50,
                 ],
-                dtype=np.float,
+                dtype=float,
             )
             / s.dx**2
         )


### PR DESCRIPTION
np.float removed in 1.24, replaced with float to fix AttributeError