### PR TITLE
Update non_interacting.py to improve speed

### DIFF
--- a/iDEA/methods/non_interacting.py
+++ b/iDEA/methods/non_interacting.py
@@ -179,7 +179,7 @@ def add_occupations(
     |     state: iDEA.state.SingleBodyState, State with occupations added.
     """
     # Calculate the max level or orbitals needed to achieve required state and only use these.
-    max_level = (k + 1) * int(np.ceil(s.count))
+    max_level = max(s.up_count,s.down_count) + k
     up_energies = state.up.energies[:max_level]
     down_energies = state.down.energies[:max_level]
 


### PR DESCRIPTION
Corrects the expression for max_levels. The maximum level occupied at k=0 is max(s.up_count,s.down_count) and at most 1 new level is occupied with each increment to k, so the maximum level occupied at k=k is max(s.up_count,s.down_count) + k. The current expression for max_level produces values that are too high, resulting in unnecessary energy levels being used. By preventing this, the proposed change makes the solve function execute much more quickly: 

![Execution Times Solving for the 1st Excited State](https://github.com/iDEA-org/iDEA/assets/139252533/becb7cb9-7add-406e-984f-b00d844e24d8)
