### PR TITLE
Corrected typos in the tutorial markdown and in undefined variable errors in interacting.py

### DIFF
--- a/iDEA/methods/interacting.py
+++ b/iDEA/methods/interacting.py
@@ -49,7 +49,7 @@ def kinetic_energy_operator(s: iDEA.system.System) -> sps.dia_matrix:
     generate_terms = lambda f, A, B, n: (
         fold_partial_operators(f, partial_operators(A, B, k, n)) for k in range(n)
     )
-    terms = generate_terms(sps.kron, h, I, s.count)
+    terms = generate_terms(sps.kron, k, I, s.count)
     K = sps.dia_matrix((s.x.shape[0] ** s.count,) * 2, dtype=float)
     for term in terms:
         K += term
@@ -78,7 +78,7 @@ def external_potential_operator(s: iDEA.system.System) -> sps.dia_matrix:
     generate_terms = lambda f, A, B, n: (
         fold_partial_operators(f, partial_operators(A, B, k, n)) for k in range(n)
     )
-    terms = generate_terms(sps.kron, h, I, s.count)
+    terms = generate_terms(sps.kron, vext, I, s.count)
     Vext = sps.dia_matrix((s.x.shape[0] ** s.count,) * 2, dtype=float)
     for term in terms:
         Vext += term

--- a/tutorial/tutorial.ipynb
+++ b/tutorial/tutorial.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "In this tutorial we will introduce you to the main functionality of iDEA. For more details, please see the full [API documentation](https://idea-interacting-dynamic-electrons-approach.readthedocs.io/en/latest/).\n",
     "\n",
-    "iDEA allows you to describe quantum mechanical systems in one dimension, and solve them for the required quantum state, from which you can calculate observables. The method to solve the system can be both exact, or a variaty of common and novel approximate methods. These states can then be propagated due to perturbations, and such evolutions can be invesigated. This allows you to both gain key insights from the exact solution, and by investigating failings of existing methods, investigate why such failings occur, and how to create new more accurate methods. In addition, iDEA can be used to create interactive visualisations of concepts from quantum mechanics and condenced matter physics, to create engaging teaching material. Also, the iDEA code, and its minimal dependencies are composed of fully free software and are highly optimised, and so can allow researchers to release notebooks with thier papers, ensuring papers can be reproduces at the touch of a button. This also increases the extent to which readers can engaage with your results. \n",
+    "iDEA allows you to describe quantum mechanical systems in one dimension, and solve them for the required quantum state, from which you can calculate observables. The method to solve the system can be both exact, or a variety of common and novel approximate methods. These states can then be propagated due to perturbations, and such evolutions can be investigated. This allows you to both gain key insights from the exact solution, and by investigating failings of existing methods, investigate why such failings occur, and how to create new more accurate methods. In addition, iDEA can be used to create interactive visualisations of concepts from quantum mechanics and condensed matter physics, to create engaging teaching material. Also, the iDEA code, and its minimal dependencies are composed of fully free software and are highly optimised, and so can allow researchers to release notebooks with their papers, ensuring papers can be reproduces at the touch of a button. This also increases the extent to which readers can engage with your results. \n",
     "\n",
     "This tutorial will follow the following outline:\n",
     "1. The \"Hello World\" of iDEA.\n",
@@ -35,7 +35,7 @@
    "source": [
     "To install iDEA, simply use pip: `pip install iDEA-latest`.\n",
     "\n",
-    "Now we can import our depencies for this tutorial:"
+    "Now we can import our dependencies for this tutorial:"
    ]
   },
   {
@@ -321,7 +321,7 @@
    "id": "f4329f2d-14de-4c6f-b4d4-dfff1292aeb2",
    "metadata": {},
    "source": [
-    "We can also compute the up and down spin-densities seperatly, and of course they are the same for this system:"
+    "We can also compute the up and down spin-densities separately, and of course they are the same for this system:"
    ]
   },
   {
@@ -555,9 +555,9 @@
    "id": "b2ef480d-bb7b-4522-9f8b-370b8a1e3091",
    "metadata": {},
    "source": [
-    "Let us define a system `s`, which contains wo electrons (both spin-up) in a quantum harmonic oscillator (QHO).\n",
+    "Let us define a system `s`, which contains two electrons (both spin-up) in a quantum harmonic oscillator (QHO).\n",
     "\n",
-    "First, let us define a x-grid from $x=-10$ to $x=10$ with $250$ grid points:"
+    "First, let us define a x-grid from $x=-10$ to $x=10$ with $150$ grid points:"
    ]
   },
   {
@@ -706,7 +706,7 @@
    "id": "6542e7d0-b98e-4af7-8544-c59e709154d4",
    "metadata": {},
    "source": [
-    "And to summerise, the code we used to build our system:"
+    "And to summarise, the code we used to build our system:"
    ]
   },
   {
@@ -815,7 +815,7 @@
    "id": "ee261938-67c8-44df-82df-c1e54b6bf898",
    "metadata": {},
    "source": [
-    "Note that this is zero along the diagonal, owing to the Pauli exclusion principle. (As an excerise, show this is not zero if the electrons have opposise spin. Hint: when building the system use `electrons = \"ud\"` insead of `\"uu\"`)"
+    "Note that this is zero along the diagonal, owing to the Pauli exclusion principle. (As an exercise, show this is not zero if the electrons have opposite spin. Hint: when building the system use `electrons = \"ud\"` instead of `\"uu\"`)"
    ]
   },
   {
@@ -2635,7 +2635,7 @@
    "id": "d6eade5e-4063-4f32-8df0-1cd527930602",
    "metadata": {},
    "source": [
-    "This is a general method, but can be used to perform many common tasks in condenced matter physics."
+    "This is a general method, but can be used to perform many common tasks in condensed matter physics."
    ]
   },
   {
@@ -3413,7 +3413,7 @@
    "source": [
     "Now you know all the basics of using iDEA to investigate and simulate quantum systems, here we will show you a \"real-world\" example.\n",
     "\n",
-    "**In the following section of code, we will compute the exact bonding curve of the 1D hyrogen molecule, and compare it to a conventional figure.**"
+    "**In the following section of code, we will compute the exact bonding curve of the 1D hydrogen molecule, and compare it to a conventional figure.**"
    ]
   },
   {
@@ -3565,16 +3565,16 @@
     "Now we recommend, using the tools we have walked through in this tutorial, you gain more experience with the iDEA code by trying to solve some of these more advanced open-ended problems:\n",
     "\n",
     "1. What does the bonding curve from part 8 look like if the electrons have the same spin?\n",
-    "2. What is the exact xc potential for the three electron 1D lithim atom.\n",
-    "3. Which approximation yeilds the most accurate density matix for the QHO.\n",
+    "2. What is the exact xc potential for the three electron 1D lithium atom.\n",
+    "3. Which approximation yields the most accurate density matrix for the QHO.\n",
     "4. What kind of field is needed to ionise an electron out of an atom in real time?\n",
-    "5. Can you modify the occupations of a Hartree-Fock calculation, to yeild the exact density?"
+    "5. Can you modify the occupations of a Hartree-Fock calculation, to yield the exact density?"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -3588,7 +3588,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Corrected a few typos in the tutorial that were mainly spelling mistakes bar one in the section describing the creation of `iDEA.system.System` objects where the markdown says a grid of 250 points is specified yet 150 points is instead used in the `numpy` command in the code cell below it. 

Corrected the typos in `kinetic_energy_operator` and `external_potential_operator` when generating terms where an undefined variable `h` was passed as the second argument to generate_terms rather than the correct operator defined at the start of the respective functions. 