### PR TITLE
Added missing import for pickle in system

### DIFF
--- a/iDEA/system.py
+++ b/iDEA/system.py
@@ -6,6 +6,7 @@ import numpy as np
 import iDEA.utilities
 import iDEA.interactions
 
+import pickle
 
 __all__ = ["System", "save_system", "load_system", "systems"]
 


### PR DESCRIPTION
This prevented, for instance, `iDEA.system.save_system` from being used since the module is not loaded in the namespace. 